### PR TITLE
better seo: update seo title and sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
-# jekyll
-_site/
-.sass-cache/
-.jekyll-cache/
-.jekyll-metadata
-
-# macos
+# macOS
 .DS_Store
 .AppleDouble
 .LSOverride
@@ -23,5 +17,32 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-# WebStorm
+# Windows
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.stackdump
+[Dd]esktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Tools
 .idea
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+.history/
+
+# jekyll
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+# Misc
+*.tmp
+*.bak

--- a/_config.yml
+++ b/_config.yml
@@ -108,5 +108,5 @@ exclude:
 - build.sh
 
 plugins:
-- jekyll-sitemap
+# - jekyll-sitemap
 - jekyll-redirect-from

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -20,6 +20,15 @@
     {%- capture seotitle -%}{{ page.title }}{%- endcapture -%}           
     {%- endif %}
     {%- comment -%}
+    Adjust the page.image URL to match the absolute or relative URL
+    {%- endcomment -%}
+    {%- assign page_img = page.image | split: "/" -%}
+    {%- unless page_img.first == "https:" or page_img.first == "http:" -%}
+    {%- capture seo_img_url -%}{{ site.url }}{{ page.image }}{%- endcapture -%}
+    {%- else -%}
+    {%- capture seo_img_url -%}{{ page.image }}{%- endcapture -%}
+    {%- endunless -%}
+    {%- comment -%}
     Set seo meta tags for pages and documents
     {%- endcomment -%}  
     <title>{{ seotitle_w_sitename }}</title>
@@ -29,7 +38,7 @@
     <meta property="og:locale" content="{{ page.lang }}" />
     <meta property="og:locale:alternate" content="{%- if page.lang == "en" -%}zh{%- else -%}en{%- endif -%}" />
     {%- if page.image %}
-    <meta property="og:image" content="{{ site.url }}{{ page.image }}" />    
+    <meta property="og:image" content="{{ seo_img_url }}" />    
     {%- endif %}
     <meta property="og:description" content="{{ page.description }}" />
     <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
@@ -45,7 +54,7 @@
             "description": "{{ page.description }}",    
             "url":"{{ site.url }}{{ page.url }}",
             {%- if page.image %}
-            "image" : "{{ site.url }}{{ page.image }}",
+            "image" : "{{ seo_img_url }}",
             {%- endif %}
             "publisher":{
                 "@type":"Organization",

--- a/robots.txt
+++ b/robots.txt
@@ -9,5 +9,3 @@ Disallow: /test/*
 Disallow: /snippets/*
 Disallow: /redirects*
 Disallow: /redirect/*
-Disallow: /assets/css/*
-Disallow: /assets/js/*

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,24 @@
+---
+layout: null
+sitemap: false
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- assign all_pages = site.pages | where: "sitemap", nil -%}
+  {%- assign all_docs = site.documents | where: "sitemap", nil | where_exp: "item", "item.collection contains 'docs_'" -%}
+  {%- for item in all_docs %}
+  <url>
+    <loc>{{ site.url }}{{ item.url }}</loc>
+    <lastmod>{{ item.date }}</lastmod>
+    <priority>1.0</priority>
+  </url>  
+  {%- endfor %}
+  {%- for item in all_pages %}
+  {%- if item.title %}
+  <url>
+    <loc>{{ site.url }}{{ item.url }}</loc>
+    <priority>1.0</priority>
+  </url>    
+  {%- endif %}
+  {%- endfor %}
+</urlset>


### PR DESCRIPTION
1. Disable jekyll-sitemap: this plug-in on Github Pages missing `<lastmod>`, it is not a big deal, but I did a template to replace it.
2. Update seo.html: to match the absolute or relative URL
3. Update robots.txt and gitignore.